### PR TITLE
adding supercedes/consistent and limiting placement of vararg

### DIFF
--- a/multipledispatch/conflict.py
+++ b/multipledispatch/conflict.py
@@ -1,4 +1,5 @@
-from .utils import _toposort, groupby
+from .utils import _toposort, groupby, VariadicSignatureType
+
 
 class AmbiguityWarning(Warning):
     pass
@@ -6,14 +7,49 @@ class AmbiguityWarning(Warning):
 
 def supercedes(a, b):
     """ A is consistent and strictly more specific than B """
-    return len(a) == len(b) and all(map(issubclass, a, b))
+    if len(a) < len(b):
+        # only case is if a is empty and b is variadic
+        return (len(a) == 0 and
+                len(b) == 1 and
+                isinstance(b[-1], VariadicSignatureType))
+    elif len(a) == len(b):
+        return all(map(issubclass, a, b))
+    else:
+        # len(a) > len(b)
+        p1 = 0
+        p2 = 0
+        while p1 < len(a) and p2 < len(b):
+            if (not isinstance(a[p1], VariadicSignatureType) and
+                    not isinstance(b[p2], VariadicSignatureType)):
+                if not issubclass(a[p1], b[p2]):
+                    return False
+                p1 += 1
+                p2 += 1
+            elif isinstance(a[p1], VariadicSignatureType):
+                assert p1 == len(a) - 1
+                return p2 == len(b) - 1 and issubclass(a[p1], b[p2])
+            elif isinstance(b[p2], VariadicSignatureType):
+                assert p2 == len(b) - 1
+                if not issubclass(a[p1], b[p2]):
+                    return False
+                p1 += 1
+        return p2 == len(b) - 1 and p1 == len(a)
 
 
 def consistent(a, b):
     """ It is possible for an argument list to satisfy both A and B """
+    def check_variadic_consistency(a, b):
+        if (len(a) == 0 or
+            (not isinstance(a[-1], VariadicSignatureType) and
+             not isinstance(b[-1], VariadicSignatureType))):
+            return True
+        else:
+            return a[-1] == b[-1]
+
     return (len(a) == len(b) and
             all(issubclass(aa, bb) or issubclass(bb, aa)
-                           for aa, bb in zip(a, b)))
+                for aa, bb in zip(a, b)) and
+            check_variadic_consistency(a, b))
 
 
 def ambiguous(a, b):
@@ -25,10 +61,10 @@ def ambiguities(signatures):
     """ All signature pairs such that A is ambiguous with B """
     signatures = list(map(tuple, signatures))
     return set([(a, b) for a in signatures for b in signatures
-                       if hash(a) < hash(b)
-                       and ambiguous(a, b)
-                       and not any(supercedes(c, a) and supercedes(c, b)
-                                    for c in signatures)])
+                if hash(a) < hash(b)
+                and ambiguous(a, b)
+                and not any(supercedes(c, a) and supercedes(c, b)
+                            for c in signatures)])
 
 
 def super_signature(signatures):
@@ -37,7 +73,7 @@ def super_signature(signatures):
     assert all(len(s) == n for s in signatures)
 
     return [max([type.mro(sig[i]) for sig in signatures], key=len)[0]
-               for i in range(n)]
+            for i in range(n)]
 
 
 def edge(a, b, tie_breaker=hash):

--- a/multipledispatch/core.py
+++ b/multipledispatch/core.py
@@ -78,7 +78,7 @@ def ismethod(func):
     """
     if hasattr(inspect, "signature"):
         signature = inspect.signature(func)
-        return signature.parameters.get('self', None) != None
+        return signature.parameters.get('self', None) is not None
     else:
         spec = inspect.getargspec(func)
         return spec and spec.args and spec.args[0] == 'self'

--- a/multipledispatch/dispatcher.py
+++ b/multipledispatch/dispatcher.py
@@ -2,7 +2,7 @@ import collections
 from warnings import warn
 import inspect
 from .conflict import ordering, ambiguities, super_signature, AmbiguityWarning
-from .utils import expand_tuples
+from .utils import expand_tuples, VariadicSignatureType
 import itertools as itl
 
 
@@ -74,15 +74,6 @@ def typename(type):
         return '(%s)' % ', '.join(map(typename, type))
 
 
-class VariadicSignatureType(type):
-    # checking if subclass is a subclass of self
-    def __subclasscheck__(self, subclass):
-        other_type = getattr(subclass, 'value_type', (subclass,))
-        return subclass is self or all(
-            issubclass(other, self.value_type) for other in other_type
-        )
-
-
 class VariadicSignatureMeta(type):
     """A metaclass that overrides ``__getitem__`` on the class. This is used to
     generate a new type for Variadic signatures. See the Variadic class for
@@ -152,12 +143,9 @@ def variadic_signature_matches_iter(types, full_signature):
             if matches:
                 yield matches
             else:
-                try:
-                    sig = next(sigiter)
-                except StopIteration:
-                    # We're out of signatures, but we still have types left to
-                    # match, so there's no possible match.
-                    yield False
+                # We're out of signatures, but we still have types left to
+                # match, so there's no possible match.
+                yield False
         else:
             # we're not matching a variadic argument, so move to the next
             # element in the signature
@@ -167,7 +155,7 @@ def variadic_signature_matches_iter(types, full_signature):
         try:
             sig = next(sigiter)
         except StopIteration:
-            assert not isinstance(sig, Variadic)
+            assert isinstance(sig, VariadicSignatureType)
             yield True
         else:
             # We have signature items left over, so all of our arguments
@@ -301,7 +289,7 @@ class Dispatcher(object):
 
         new_signature = []
 
-        for typ in signature:
+        for index, typ in enumerate(signature):
             if not isinstance(typ, (type, list)):
                 str_sig = ', '.join(c.__name__ if isinstance(c, type)
                                     else str(c) for c in signature)
@@ -312,6 +300,8 @@ class Dispatcher(object):
 
             # handle variadic signatures
             if isinstance(typ, list):
+                assert index == len(signature) - 1, \
+                    'Variadic signature must be the last element'
                 assert len(typ) == 1, \
                     'Variadic signature must contain exactly one element'
                 new_signature.append(Variadic[typ[0]])

--- a/multipledispatch/dispatcher.py
+++ b/multipledispatch/dispatcher.py
@@ -289,7 +289,7 @@ class Dispatcher(object):
 
         new_signature = []
 
-        for index, typ in enumerate(signature):
+        for index, typ in enumerate(signature, start=1):
             if not isinstance(typ, (type, list)):
                 str_sig = ', '.join(c.__name__ if isinstance(c, type)
                                     else str(c) for c in signature)
@@ -300,7 +300,7 @@ class Dispatcher(object):
 
             # handle variadic signatures
             if isinstance(typ, list):
-                assert index == len(signature) - 1, \
+                assert index == len(signature), \
                     'Variadic signature must be the last element'
                 assert len(typ) == 1, \
                     'Variadic signature must contain exactly one element'

--- a/multipledispatch/tests/test_conflict.py
+++ b/multipledispatch/tests/test_conflict.py
@@ -1,5 +1,6 @@
 from multipledispatch.conflict import (supercedes, ordering, ambiguities,
         ambiguous, super_signature, consistent)
+from multipledispatch.dispatcher import Variadic
 
 
 class A(object): pass
@@ -60,3 +61,31 @@ def test_ordering():
 
 def test_type_mro():
     assert super_signature([[object], [type]]) == [type]
+
+
+def test_supercedes_variadic():
+    assert supercedes([Variadic[B]], [Variadic[A]])
+    assert supercedes([B, Variadic[A]], [Variadic[A]])
+    assert supercedes([Variadic[A]], [Variadic[(A, C)]])
+    assert supercedes([A, B, Variadic[C]], [Variadic[object]])
+    assert supercedes([A, Variadic[B]], [Variadic[A]])
+    assert supercedes([], [Variadic[A]])
+    assert supercedes([A, A, A], [A, Variadic[A]])
+    assert not supercedes([Variadic[A]], [Variadic[B]])
+    assert not supercedes([Variadic[A]], [B, Variadic[A]])
+    assert not supercedes([Variadic[(A, C)]], [Variadic[A]])
+    assert not supercedes([Variadic[object]], [A, B, Variadic[C]])
+    assert not supercedes([Variadic[A]], [A, Variadic[B]])
+    assert not supercedes([Variadic[A]], [])
+    assert not supercedes([A, Variadic[A]], [A, A, A])
+
+
+def test_consistent_variadic():
+    assert consistent([Variadic[A]], [Variadic[A]])
+    assert consistent([Variadic[B]], [Variadic[B]])
+    assert not consistent([Variadic[C]], [Variadic[A]])
+    assert not consistent([Variadic[(A, C)]], [Variadic[A]])
+    assert not consistent([A, A, B], [A, A, Variadic[B]])
+
+    assert consistent([A, B, Variadic[C]], [B, A, Variadic[C]])
+    assert not consistent([A, B, Variadic[C]], [B, A, Variadic[(C, B)]])

--- a/multipledispatch/tests/test_conflict.py
+++ b/multipledispatch/tests/test_conflict.py
@@ -64,28 +64,43 @@ def test_type_mro():
 
 
 def test_supercedes_variadic():
-    assert supercedes([Variadic[B]], [Variadic[A]])
-    assert supercedes([B, Variadic[A]], [Variadic[A]])
-    assert supercedes([Variadic[A]], [Variadic[(A, C)]])
-    assert supercedes([A, B, Variadic[C]], [Variadic[object]])
-    assert supercedes([A, Variadic[B]], [Variadic[A]])
-    assert supercedes([], [Variadic[A]])
-    assert supercedes([A, A, A], [A, Variadic[A]])
-    assert not supercedes([Variadic[A]], [Variadic[B]])
-    assert not supercedes([Variadic[A]], [B, Variadic[A]])
-    assert not supercedes([Variadic[(A, C)]], [Variadic[A]])
-    assert not supercedes([Variadic[object]], [A, B, Variadic[C]])
-    assert not supercedes([Variadic[A]], [A, Variadic[B]])
-    assert not supercedes([Variadic[A]], [])
-    assert not supercedes([A, Variadic[A]], [A, A, A])
+    assert supercedes((Variadic[B],), (Variadic[A],))
+    assert supercedes((B, Variadic[A]), (Variadic[A],))
+    assert supercedes((Variadic[A],), (Variadic[(A, C)],))
+    assert supercedes((A, B, Variadic[C]), (Variadic[object],))
+    assert supercedes((A, Variadic[B]), (Variadic[A],))
+    assert supercedes(tuple([]), (Variadic[A],))
+    assert supercedes((A, A, A), (A, Variadic[A]))
+    assert not supercedes((Variadic[A],), (Variadic[B],))
+    assert not supercedes((Variadic[A],), (B, Variadic[A]))
+    assert not supercedes((Variadic[(A, C)],), (Variadic[A],))
+    assert not supercedes((Variadic[object],), (A, B, Variadic[C]))
+    assert not supercedes((Variadic[A],), (A, Variadic[B]))
+    assert not supercedes((Variadic[A],), tuple([]))
+    assert not supercedes((A, Variadic[A]), (A, A, A))
 
 
 def test_consistent_variadic():
-    assert consistent([Variadic[A]], [Variadic[A]])
-    assert consistent([Variadic[B]], [Variadic[B]])
-    assert not consistent([Variadic[C]], [Variadic[A]])
-    assert not consistent([Variadic[(A, C)]], [Variadic[A]])
-    assert not consistent([A, A, B], [A, A, Variadic[B]])
+    # basic check
+    assert consistent((Variadic[A],), (Variadic[A],))
+    assert consistent((Variadic[B],), (Variadic[B],))
+    assert not consistent((Variadic[C],), (Variadic[A],))
 
-    assert consistent([A, B, Variadic[C]], [B, A, Variadic[C]])
-    assert not consistent([A, B, Variadic[C]], [B, A, Variadic[(C, B)]])
+    # union types
+    assert consistent((Variadic[(A, C)],), (Variadic[A],))
+    assert consistent((Variadic[(A, C)],), (Variadic[(C, A)],))
+    assert consistent((Variadic[(A, B, C)],), (Variadic[(C, B, A)],))
+    assert consistent((A, B, C), (Variadic[(A, B, C)],))
+    assert consistent((A, B, C), (A, Variadic[(B, C)]))
+
+    # more complex examples
+    assert consistent(tuple([]), (Variadic[object],))
+    assert consistent((A, A, B), (A, A, Variadic[B]))
+    assert consistent((A, A, B), (A, A, Variadic[A]))
+    assert consistent((A, B, Variadic[C]), (B, A, Variadic[C]))
+    assert consistent((A, B, Variadic[C]), (B, A, Variadic[(C, B)]))
+
+    # not consistent
+    assert not consistent((C,), (Variadic[A],))
+    assert not consistent((A, A, Variadic[C]), (A, Variadic[C]))
+    assert not consistent((A, B, Variadic[C]), (C, B, Variadic[C]))

--- a/multipledispatch/utils.py
+++ b/multipledispatch/utils.py
@@ -9,15 +9,9 @@ class VariadicSignatureType(type):
             issubclass(other, self.value_type) for other in other_type
         )
 
-    def __eq__(self, other):
-        """
-        Return true if we have the same value type
-        """
-        return (isinstance(other, VariadicSignatureType) and
-                self.value_type == other.value_type)
 
-    def __hash__(self):
-        return hash(self.value_type)
+def isvariadic(obj):
+    return isinstance(obj, VariadicSignatureType)
 
 
 def raises(err, lamda):
@@ -73,7 +67,7 @@ def _toposort(edges):
     L = []
 
     while S:
-        n = S.popitem()[0]
+        n, _ = S.popitem()
         L.append(n)
         for m in edges.get(n, ()):
             assert n in incoming_edges[m]


### PR DESCRIPTION
This limits the placement of the Variadic argument to the end of the argument list which

- Decreases complexity / runtime of logic in `supercedes` and `consistent`
- Makes syntax more similar to python function arguments `func(a, b, *args)`

This was tested with added unit tests in `test_conflict.py` and `test_dispatcher.py` and very briefly tested manually using `@dispatch`. 

`OrderedDict` was used to get deterministic ordering from `_toposort`
